### PR TITLE
Fix typo in mixins' example code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -375,7 +375,7 @@ ComponentSubs.prototype.subscribe = function() {
 ComponentSubs.prototype.ready = function() {
   var ready = true;
   this._subs.forEach(function(sub) {
-    ready = sub.ready();
+    ready = ready && sub.ready();
   });
 
   return ready;


### PR DESCRIPTION
It seems there is a mistake in README.md. In mixins code example the result should not be determined by the last subscribtion only, right?